### PR TITLE
Revert "Bump highlight.js from 9.18.1 to 10.4.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4837,9 +4837,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-      "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ=="
     },
     "hipchat-notifier": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "angular-svg-round-progressbar": "^2.0.0",
     "core-js": "^2.5.7",
     "hammerjs": "^2.0.8",
-    "highlight.js": "^10.4.1",
+    "highlight.js": "^9.12.0",
     "leaflet": "^1.7.1",
     "ng2-odometer": "^1.1.3",
     "ng2-page-transition": "^1.1.0",


### PR DESCRIPTION
Reverts X-CASH-official/delegates-explorer#5