### PR TITLE
fix: order of top block verifier in statistics

### DIFF
--- a/src/app/statistics/statistics.component.ts
+++ b/src/app/statistics/statistics.component.ts
@@ -65,16 +65,16 @@ export class statisticsComponent implements OnInit {
             let data = JSON.parse(JSON.stringify(res));
             let count = 0;
             let top_count = 25;
-
-            this.top_producer = data.sort(function(a, b) {
+            // Top Block Producer List
+            this.top_producer = [...data].sort(function(a, b) {
               return b.block_producer_total_rounds - a.block_producer_total_rounds;
             }).slice( 0, top_count);
-
-            this.top_verifier = data.sort(function(a, b) {
+            // Top Block Verifier List
+            this.top_verifier = [...data].sort(function(a, b) {
               return b.block_verifier_total_rounds - a.block_verifier_total_rounds;
             }).slice( 0, top_count);
-
-            data.map(function(item) {
+            // Top Block Ratio List
+            [...data].map(function(item) {
                item.block_ratio = item.block_producer_total_rounds / item.block_verifier_total_rounds * 100;
             });
             this.top_ratio = data.sort(function(a, b) {


### PR DESCRIPTION
# Description

Fix of order of top block verifier in statistics
[http://delegates.xcash.rocks/statistics](http://delegates.xcash.rocks/statistics)

Style of API "Example Response" and "ES6 Snippet" indentation
[http://delegates.xcash.rocks/API](http://delegates.xcash.rocks/API)

Style of tables: center column block_height and form text
[http://delegates.xcash.rocks/delegates/delegate_statistics?data=zachy.zone](http://delegates.xcash.rocks/delegates/delegate_statistics?data=zachy.zone)


## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

