### PR TITLE
Look and feel update

### DIFF
--- a/src/app/tables/delegates/delegates.component.html
+++ b/src/app/tables/delegates/delegates.component.html
@@ -1,3 +1,12 @@
+<div fxLayout="column" fxLayout.lt-sm="column"  class="components-container-gt-xs deleagtes_table"  [ngClass.xs]="'components-container-xs'"   fxLayoutGap="20px">
+	<div fxFlex.xs="100" fxFlex.lg="50" fxFlex.md="50" fxFlex.sm="50"  fxLayoutGap="20px" class="filterButtons">
+		<button  mat-raised-button  fxFlex.lt-sm="50" fxFlex.md="25"  color="accent" [ngClass]="filter_active == '' ? 'on' : 'off'" (click)="filterMode('')"  matTooltip="Show All Nodes"><mat-icon>select_all</mat-icon> All</button>
+		<button  mat-raised-button  fxFlex.lt-sm="50" fxFlex.md="25"  color="accent" [ngClass]="filter_active == 'Shared' ? 'on' : 'off'" (click)="filterMode('Shared')"  matTooltip="Show Shared Nodes"><mat-icon>groups</mat-icon> Shared</button>
+		<button  mat-raised-button  fxFlex.lt-sm="50" fxFlex.md="25"  color="accent" [ngClass]="filter_active == 'Group' ? 'on' : 'off'" (click)="filterMode('Group')"  matTooltip="Show Private Groups"><mat-icon>lock</mat-icon> Group</button>
+		<button  mat-raised-button  fxFlex.lt-sm="50" fxFlex.md="25"  color="accent" [ngClass]="filter_active == 'Solo' ? 'on' : 'off'" (click)="filterMode('Solo')"  matTooltip="Show Solo Nodes"><mat-icon>person_outline</mat-icon>Solo</button>
+	</div>
+</div>
+
 
 <div fxLayout="column"  class="components-container-gt-xs deleagtes_table"  [ngClass.xs]="'components-container-xs'"  fxLayoutGap="5px">
 
@@ -19,8 +28,17 @@
 
 
 				<ng-container matColumnDef="id">
-					<mat-header-cell *matHeaderCellDef mat-sort-header> ID </mat-header-cell>
-					<mat-cell id="id{{row.id}}" *matCellDef="let row">{{ row.id | number}}</mat-cell>
+					<mat-header-cell *matHeaderCellDef mat-sort-header>
+						<mat-icon *ngIf="mobile; else status" matTooltip="Rank">filter_list</mat-icon>
+						<ng-template #status>
+							Rank
+						</ng-template>
+						</mat-header-cell>
+					<mat-cell id="id{{row.id}}" *matCellDef="let row">
+						<span [ngStyle]="{'color': row.id <= 50 ? 'green' : 'orange'}" [matTooltip]="row.id <= 50 ? 'Verifier/Producer' : 'Standby'">
+							{{ row.id | number}}
+						</span>
+					</mat-cell>
 				</ng-container>
 
 				<ng-container matColumnDef="delegate_name">
@@ -64,8 +82,8 @@
 					<mat-cell id="shared_delegate_status{{row.id}}" *matCellDef="let row">
 
 						<mat-icon *ngIf="row.shared_delegate_status === 'Solo';" matTooltip="Solo Node">person_outline</mat-icon>
-                                                <mat-icon *ngIf="row.shared_delegate_status === 'Shared';" matTooltip="Shared Node - {{ row.delegate_fee + '%' }} Fee">groups</mat-icon>
-                                                <mat-icon *ngIf="row.shared_delegate_status === 'Group';" matTooltip="Private Group">lock</mat-icon>
+            <mat-icon *ngIf="row.shared_delegate_status === 'Shared';" matTooltip="Shared Node - {{ row.delegate_fee + '%' }} Fee">groups</mat-icon>
+            <mat-icon *ngIf="row.shared_delegate_status === 'Group';" matTooltip="Private Group">lock</mat-icon>
 
 					</mat-cell>
 				</ng-container>

--- a/src/app/tables/delegates/delegates.component.html
+++ b/src/app/tables/delegates/delegates.component.html
@@ -29,7 +29,7 @@
 
 				<ng-container matColumnDef="id">
 					<mat-header-cell *matHeaderCellDef mat-sort-header>
-						<mat-icon *ngIf="mobile; else status" matTooltip="Rank">filter_list</mat-icon>
+						<mat-icon *ngIf="mobile; else status" matTooltip="Rank">leaderboard</mat-icon>
 						<ng-template #status>
 							Rank
 						</ng-template>

--- a/src/app/tables/delegates/delegates.component.html
+++ b/src/app/tables/delegates/delegates.component.html
@@ -144,7 +144,7 @@
 				[length]="length"
 				[pageIndex]="0"
 				[pageSize]="pagesize"
-				[pageSizeOptions]="[ 50, 100, 150, 200]">
+				[pageSizeOptions]="[ 100, 150, 200]">
 			</mat-paginator>
 
 		</div>

--- a/src/app/tables/delegates/delegates.component.scss
+++ b/src/app/tables/delegates/delegates.component.scss
@@ -31,6 +31,8 @@
 	flex-direction: column;
 	justify-content: center;
 	text-align: center;
+	font-weight: 500;
+	font-size: 18px;
 }
 .mat-column-delegate_name {
 	flex: 4 1 16%;
@@ -107,8 +109,16 @@ mat-cell:last-of-type  { padding-right: 6px;}
 	.mat-column-delegate_fee{
 	  display: none;
 	}
+	.filterButtons > .mat-raised-button{
+		padding-left: 0px;
+		padding-right: 0px;
+	}
 
 }
 mat-cell.mat-column-online_status > mat-icon,
 mat-cell.mat-column-shared_delegate_status >  mat-icon,
 mat-cell.mat-column-total_vote_count > span { cursor: help; }
+
+.filterButtons {
+	padding-top: 15px;
+}

--- a/src/app/tables/delegates/delegates.component.scss
+++ b/src/app/tables/delegates/delegates.component.scss
@@ -27,7 +27,7 @@
 
 
 .mat-column-id {
-	flex: 1 0 24px;
+	flex: 1 0 30px;
 	flex-direction: column;
 	justify-content: center;
 	text-align: center;

--- a/src/app/tables/delegates/delegates.component.ts
+++ b/src/app/tables/delegates/delegates.component.ts
@@ -85,7 +85,7 @@ export class DelegatesComponent implements OnInit {
 
         // paginator settings
         this.length = data.length;
-        this.pagesize = 50;
+        this.pagesize = 100;
 
         this.dataSource = new DelegateDataSource(this.exampleDatabase, this.paginator, this.sort);
 

--- a/src/app/tables/delegates/delegates.component.ts
+++ b/src/app/tables/delegates/delegates.component.ts
@@ -8,6 +8,7 @@ import { FunctionsService } from '../../services/functions.service';
 import { MatPaginator, MatSort } from '@angular/material';
 import { Title } from '@angular/platform-browser';
 
+
 import Swal from 'sweetalert2';
 import {MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltipDefaultOptions} from '@angular/material/tooltip';
 
@@ -36,6 +37,7 @@ export class DelegatesComponent implements OnInit {
   length;
   pagesize;
   mobile = false;
+  filter_active = '';
 
 
 	constructor(private httpdataservice: HttpdataService, private titleService:Title, public functionsService: FunctionsService) {
@@ -58,9 +60,9 @@ export class DelegatesComponent implements OnInit {
       this.mobile = true;
     }
 
-
     this.get_delegates();
   }
+
 
 
 	get_delegates() {
@@ -89,6 +91,7 @@ export class DelegatesComponent implements OnInit {
 
         this.dataSource = new DelegateDataSource(this.exampleDatabase, this.paginator, this.sort);
 
+        console.log(this.filter_active);
 
         observableFromEvent(this.filter.nativeElement, 'keyup').pipe(
           debounceTime(150),
@@ -105,6 +108,13 @@ export class DelegatesComponent implements OnInit {
     );
   }
 
+
+  filterMode(value) {
+    this.dataSource.filter = value;
+    this.filter_active = value;
+    console.log(value);
+    console.log(this.filter_active);
+  }
 
 
 

--- a/src/theme/theme.scss
+++ b/src/theme/theme.scss
@@ -110,6 +110,8 @@ $spin_background-darksea: mat-palette($warning-darksea, 900, 0.9);
   span.hljs-literal { color: mat-color($md-xorange,500); }
   .Online { color:  mat-color($mat-green,500); }
   .Offline { color: mat-color($mat-red,500); }
+  .on {color: white; background-color: $warn-darksea !important; }
+  .off {color: white; background-color: mat-color($accent-darksea,700) !important;}
   .mat-tooltip{
       border: 1px solid $pri-darksea;
       background-color: #ffffff;
@@ -188,8 +190,8 @@ $warning-unicorn : $mat-lime;
   a{  color: mat-color($primary-unicorn,A100); text-decoration: none; }
   a:hover {  color: mat-color($accent-unicorn,500); }
    // Buttons
-  .delegate_details {  color: white; background-color:mat-color($accent-unicorn,500); }
-  .delegate_details_active, a.delegate_details:hover  {  color: mat-color($primary-unicorn,A100); background-color: $bg-unicorn; }
+  .off, .delegate_details {  color: white !important; background-color:mat-color($accent-unicorn,500)  !important; }
+  .on, .delegate_details_active, a.delegate_details:hover  {  color: mat-color($primary-unicorn,A100) !important; background-color: $bg-unicorn  !important; }
   .mat-raised-button.mat-warn { color: white; background-color:mat-color($accent-unicorn,500); }
   .mat-raised-button:hover, .service-card-container .service-card a:hover  { color: mat-color($primary-unicorn,500); background-color: $bg-unicorn; }
   // ...
@@ -253,8 +255,8 @@ $warning-unicorn : $mat-lime;
   .page_title_icon { color: white; }
   .dashcard_icon { color: white; background-color: mat-color($accent-xteal,500); }
   .dashcard_box { color: white; background-color: mat-color($primary-xteal,500); }
-  .delegate_details{  color: white; background-color: mat-color($warn-xteal,600); }
-  .delegate_details_active{  color: white; background-color:mat-color($accent-xteal,500); }
+  .off, .delegate_details{  color: white; background-color: mat-color($warn-xteal,600); }
+  .on, .delegate_details_active{  color: white; background-color:mat-color($accent-xteal,500); }
   .codeblock {  color: mat-color($primary-xteal,500); background: white; border: 2px solid white; }
   a{ color: mat-color($primary-xteal,500); text-decoration: none; }
   a:hover { color: mat-color($accent-xteal,500); }
@@ -270,6 +272,8 @@ $warning-unicorn : $mat-lime;
   .cards-container {  border: 2px solid mat-color($primary-xteal,500); }
   .Online{	color:  mat-color($mat-green,500); }
   .Offline{	color: mat-color($mat-red,500); }
+  .on {color: white !important; background-color:mat-color($accent-xteal,500) !important;}
+  .off {color: white !important; background-color: mat-color($warn-xteal,600) !important;}
   .mat-tooltip{
       border: 1px solid mat-color($primary-xteal,500);
       background-color: #ffffff;
@@ -277,7 +281,6 @@ $warning-unicorn : $mat-lime;
       &.red-tooltip{ color: red; }
       &.green-tooltip{ color: green; }
   }
-
   .mat-expansion-panel:not(.mat-expanded) .mat-expansion-panel-header:not([aria-disabled="true"]):hover, ::ng-deep .mat-expansion-indicator::after {  color: white;  }
   .mat-expansion-indicator::after {  color: white;  }
 }
@@ -319,8 +322,8 @@ $warning-unicorn : $mat-lime;
   .page_title_icon { color: white; }
   .dashcard_icon { color: white; background-color: mat-color($accent-xgrey,500); }
   .dashcard_box { color: white; background-color: mat-color($primary-xgrey,500); }
-  .delegate_details{ color: white; background-color: mat-color($warn-xgrey,600); }
-  .delegate_details_active{ color: white; background-color:mat-color($accent-xgrey,500); }
+  .off, .delegate_details{ color: white !important; background-color: mat-color($warn-xgrey,600) !important; }
+  .on, .delegate_details_active{ color: white !important; background-color:mat-color($accent-xgrey,500) !important; }
   .codeblock { color: mat-color($primary-xgrey,500); background: white;     border: 2px solid white; }
   a { color: white; }
   a:hover { color: mat-color($accent-xgrey,500); }


### PR DESCRIPTION
# Description

Improvements of the delegates list:

- delegates list pagination size to 100
- increase rank col width and change mobile icon to leaderboard
- add global filter by Mode for delegates list 
- id/rank color green if top50 else orange

 http://delegates.xcash.rocks/delegates



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


http://delegates.xcash.rocks/delegates

