### PR TITLE
fix: replace index.html with index.testnet.html on testnet environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ To build the delegate explorer for the production (mainnet) environment, go to t
 npm run build
 ```
 
-Optional you can build the delegate explorer for the testnet run:
+Optionally, you can build the delegate explorer for the testnet with the command:
 ```shell
 ng build --aot=true --build--optimizer=true -c testnet
 ```

--- a/README.md
+++ b/README.md
@@ -151,8 +151,18 @@ Edit the `delegates-explorer/src/environments/environment.prod.ts` , set your Ba
 
 ```
 export const environment = {
-    baseURL: "http://delegates.your-domain.tld",
-    apiEndPoint: ''
+    baseURL: "",
+    apiEndPoint: '',
+    explorerApiEndPoint: 'https://explorer.xcash.foundation',
+    announcementJSON: 'https://raw.githubusercontent.com/X-CASH-official/delegates-explorer/master/announcement.json',
+    shortTitle: 'Delegates Explorer',
+    seedNodes: [
+                'us1_xcash_foundation',
+                'europe1_xcash_foundation',
+                'europe2_xcash_foundation',
+                'europe3_xcash_foundation',
+                'oceania1_xcash_foundation'
+              ]
 };
 ```
 
@@ -178,9 +188,14 @@ Run the firewall script
 
 #### Build
 
-To build the delegate explorer, go to the `delegates-explorer` folder and run:
+To build the delegate explorer for the production (mainnet) environment, go to the `delegates-explorer` folder and run:
 ```shell
 npm run build
+```
+
+Optional you can build the delegate explorer for the testnet run:
+```shell
+ng build --aot=true --build--optimizer=true -c testnet
 ```
 
 It will build in the `dist`folder.

--- a/angular.json
+++ b/angular.json
@@ -46,7 +46,10 @@
                   "with": "src/environments/environment.testnet.ts"
                 }
               ],
-              "index": "src/index.testnet.html"
+              "index": {
+                "input": "src/index.testnet.html",
+                "output": "index.html"
+              }
             }
           }
         },

--- a/src/app/dashboard-crm/dashboard-crm.component.ts
+++ b/src/app/dashboard-crm/dashboard-crm.component.ts
@@ -145,10 +145,11 @@ export class DashboardCrmComponent implements OnInit {
             delegate_total_vote_count += current_delegate_total_vote_count2;
           }
 
-          this.dashCard1[8].text = this.functionsService.get_lg_numer_format(parseInt(data2[49].total_vote_count) / this.httpdataservice.XCASH_WALLET_DECIMAL_PLACES_AMOUNT );
+          this.dashCard1[8].text = this.functionsService.get_lg_numer_format(parseInt(data2[environment.totalBlockVerifiers - 1].total_vote_count) / this.httpdataservice.XCASH_WALLET_DECIMAL_PLACES_AMOUNT );
           // only use 45 to calculate this since there are no votes for the 5 seed nodes
-          var avg_vote_count = this.functionsService.get_lg_numer_format(delegate_total_vote_count / (environment.totalBlockVerifiers-5));
+          var avg_vote_count = this.functionsService.get_lg_numer_format(delegate_total_vote_count / environment.totalBlockVerifiers - 5);
           this.dashCard1[5].text = avg_vote_count;
+
         },
         (error) => {
           Swal.fire({

--- a/src/app/dashboard-crm/dashboard-crm.component.ts
+++ b/src/app/dashboard-crm/dashboard-crm.component.ts
@@ -66,7 +66,7 @@ export class DashboardCrmComponent implements OnInit {
     }
 
     get_announcement() {
-      // get the data
+      // get the data from blockchain explorer
       this.httpdataservice.get_request(environment.announcementJSON).subscribe(
         (res) => {
           var announcementData = JSON.parse(JSON.stringify(res));
@@ -77,7 +77,7 @@ export class DashboardCrmComponent implements OnInit {
 
     get_blockheight() {
       // get the data
-      this.httpdataservice.get_request('https://explorer.x-cash.org/getlastblockdata').subscribe(
+      this.httpdataservice.get_request(this.httpdataservice.GET_LAST_BLOCK_DATA).subscribe(
         (res) => {
           var data = JSON.parse(JSON.stringify(res));
 

--- a/src/app/dashboard-crm/dashboard-crm.component.ts
+++ b/src/app/dashboard-crm/dashboard-crm.component.ts
@@ -36,7 +36,7 @@ export class DashboardCrmComponent implements OnInit {
       { ogmeter: false,  width_icon: 25, text_size: 40, text: 0, suffix: '', title: 'AVERAGE DELEGATE TOTAL VOTE', icon: 'signal_cellular_null' },
       { ogmeter: true,  width_icon: 25, text_size: 40, text: 0, suffix: '%', title: 'PoS CIRCULATING', icon: 'pie_chart' },
       { ogmeter: true,  width_icon: 25, text_size: 40, text: 0, suffix: '', title: 'DPoPS ROUND NUMBER', icon: 'autorenew' },
-      { ogmeter: false,  width_icon: 25, text_size: 40, text: 0, suffix: '', title: 'RANK 50 TOTAL VOTE ', icon: 'swap_vert' },
+      { ogmeter: false,  width_icon: 25, text_size: 40, text: 0, suffix: '', title: 'RANK '+ environment.totalBlockVerifiers +' TOTAL VOTE ', icon: 'swap_vert' },
       { ogmeter: false,  width_icon: 25, text_size: 40, text: 0, suffix: '', title: 'BLOCK REWARD ', icon: 'toll' },
       { ogmeter: false,  width_icon: 25, text_size: 40, text: 0, suffix: '', title: 'BLOCK TIME ', icon: 'timelapse' },
       { ogmeter: false,  width_icon: 25, text_size: 40, text: 0, suffix: '', title: 'EST. BLOCK PER DAY ', icon: 'view_week' },
@@ -107,7 +107,7 @@ export class DashboardCrmComponent implements OnInit {
           var data = JSON.parse(JSON.stringify(res));
           this.dashCard1[7].text = data.XCASH_DPOPS_round_number;
           this.dashCard1[1].text = data.current_block_height;
-          this.dashCard1[2].text = 50;
+          this.dashCard1[2].text = environment.totalBlockVerifiers;
           this.dashCard1[4].text = this.functionsService.get_lg_numer_format(parseInt(data.total_votes) / this.httpdataservice.XCASH_WALLET_DECIMAL_PLACES_AMOUNT);
           this.dashCard1[6].text = parseInt(data.XCASH_DPOPS_circulating_percentage);
         },
@@ -147,7 +147,7 @@ export class DashboardCrmComponent implements OnInit {
 
           this.dashCard1[8].text = this.functionsService.get_lg_numer_format(parseInt(data2[49].total_vote_count) / this.httpdataservice.XCASH_WALLET_DECIMAL_PLACES_AMOUNT );
           // only use 45 to calculate this since there are no votes for the 5 seed nodes
-          var avg_vote_count = this.functionsService.get_lg_numer_format(delegate_total_vote_count/45);
+          var avg_vote_count = this.functionsService.get_lg_numer_format(delegate_total_vote_count / (environment.totalBlockVerifiers-5));
           this.dashCard1[5].text = avg_vote_count;
         },
         (error) => {

--- a/src/app/services/http-request.service.ts
+++ b/src/app/services/http-request.service.ts
@@ -5,7 +5,7 @@ import { environment } from './../../environments/environment';
 
 @Injectable()
 export class HttpdataService{
-  
+
   constructor(private httpClient: HttpClient) {}
 
   GET_STATISTICS:string = environment.apiEndPoint + "/delegateswebsitegetstatistics";
@@ -17,6 +17,7 @@ export class HttpdataService{
   GET_PUBLIC_ADDRESS_PAYMENT_INFORMATION:string = environment.apiEndPoint + "/getpublicaddresspaymentinformation";
   XCASH_WALLET_DECIMAL_PLACES_AMOUNT:number = 1000000;
   BLOCK_TIME:number = 5;
+  GET_LAST_BLOCK_DATA:string = environment.explorerApiEndPoint + "/getlastblockdata";
 
   Timer:any;
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 export const environment = {
     baseURL: "http://delegates.xcash.foundation",
     apiEndPoint: '',
+    explorerApiEndPoint: 'https://explorer.xcash.foundation',
     announcementJSON: 'https://raw.githubusercontent.com/X-CASH-official/delegates-explorer/master/announcement.json',
     shortTitle: 'Delegates Explorer',
     seedNodes: [

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -4,6 +4,7 @@ export const environment = {
     explorerApiEndPoint: 'https://explorer.xcash.foundation',
     announcementJSON: 'https://raw.githubusercontent.com/X-CASH-official/delegates-explorer/master/announcement.json',
     shortTitle: 'Delegates Explorer',
+    totalBlockVerifiers: 50,
     seedNodes: [
                 'us1_xcash_foundation',
                 'europe1_xcash_foundation',

--- a/src/environments/environment.testnet.ts
+++ b/src/environments/environment.testnet.ts
@@ -1,6 +1,7 @@
 export const environment = {
     baseURL: "http://dpops-test-delegates.xcash.foundation",
-    apiEndPoint: '',
+    apiEndPoint: 'http://dpops-test-delegates.xcash.foundation',
+    explorerApiEndPoint: 'https://explorer.testnet.x-delegate.io',
     announcementJSON: 'https://raw.githubusercontent.com/X-CASH-official/delegates-explorer/testnet/announcement.json',
     shortTitle: 'Testnet Explorer',
     seedNodes: [

--- a/src/environments/environment.testnet.ts
+++ b/src/environments/environment.testnet.ts
@@ -4,6 +4,7 @@ export const environment = {
     explorerApiEndPoint: 'https://explorer.testnet.x-delegate.io',
     announcementJSON: 'https://raw.githubusercontent.com/X-CASH-official/delegates-explorer/testnet/announcement.json',
     shortTitle: 'Testnet Explorer',
+    totalBlockVerifiers: 30,
     seedNodes: [
                 'dpops_test_1_xcash_foundation',
                 'dpops_test_2_xcash_foundation',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,6 +4,7 @@ export const environment = {
     explorerApiEndPoint: 'https://explorer.xcash.foundation',
     announcementJSON: 'https://raw.githubusercontent.com/X-CASH-official/delegates-explorer/testnet/announcement.json',
     shortTitle: 'Local Explorer',
+    totalBlockVerifiers: 50,
     seedNodes: [
                 'us1_xcash_foundation',
                 'europe1_xcash_foundation',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,7 @@
 export const environment = {
     baseURL: "http://localhost:4200",
     apiEndPoint: 'http://delegates.xcash.foundation',
+    explorerApiEndPoint: 'https://explorer.xcash.foundation',
     announcementJSON: 'https://raw.githubusercontent.com/X-CASH-official/delegates-explorer/testnet/announcement.json',
     shortTitle: 'Local Explorer',
     seedNodes: [

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
     <meta property="og:description" content="X-Cash Delegates Explorer for DPoPs nodes. Check delegates, votes, statistics and blocks information.">
     <meta property="og:image" content="http://delegates.xcash.foundation/assets/icons/apple-touch-icon-180x180.png">
 
-    <meta name="twitter:card" content="app">
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:domain" value="delegates.xcash.foundation" />
     <meta name="twitter:title" value="X-Cash Delegates Explorer" />
     <meta name="twitter:text:title" value="X-Cash Delegates Explorer" />

--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,7 @@
     <meta name="twitter:card" content="app">
     <meta name="twitter:domain" value="delegates.xcash.foundation" />
     <meta name="twitter:title" value="X-Cash Delegates Explorer" />
+    <meta name="twitter:text:title" value="X-Cash Delegates Explorer" />
     <meta name="twitter:description" value="X-Cash Delegates Explorer for DPoPs nodes. Check delegates, votes, statistics and blocks information." />
     <meta name="twitter:image" content="http://delegates.xcash.foundation/assets/icons/apple-touch-icon-180x180.png" />
     <meta name="twitter:url" value="http://delegates.xcash.foundation" />

--- a/src/index.testnet.html
+++ b/src/index.testnet.html
@@ -18,6 +18,7 @@
     <meta name="twitter:card" content="app">
     <meta name="twitter:domain" value="delegates.xcash.foundation" />
     <meta name="twitter:title" value="X-Cash Testnet Delegates Explorer" />
+    <meta name="twitter:text:title" value="X-Cash Testnet Delegates Explorer" />
     <meta name="twitter:description" value="X-Cash Testnet Delegates Explorer for DPoPs nodes. Check delegates, votes, statistics and blocks information." />
     <meta name="twitter:image" content="http://delegates.xcash.foundation/assets/icons/apple-touch-icon-180x180.png" />
     <meta name="twitter:url" value="http://delegates.xcash.foundation" />

--- a/src/index.testnet.html
+++ b/src/index.testnet.html
@@ -15,7 +15,7 @@
     <meta property="og:description" content="X-Cash Testnet Delegates Explorer for DPoPs nodes. Check delegates, votes, statistics and blocks information.">
     <meta property="og:image" content="http://delegates.xcash.foundation/assets/icons/apple-touch-icon-180x180.png">
 
-    <meta name="twitter:card" content="app">
+    <meta name="twitter:card" content="summary" />
     <meta name="twitter:domain" value="delegates.xcash.foundation" />
     <meta name="twitter:title" value="X-Cash Testnet Delegates Explorer" />
     <meta name="twitter:text:title" value="X-Cash Testnet Delegates Explorer" />


### PR DESCRIPTION
# Description

Replace index.html depending on environment.
Fixes the "cant get the file" issue on a testnet environment build caused by the missing index.html

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`ng build -c testnet --aot`

http://delegates.xcash.rocks




